### PR TITLE
Drop usage of early_config, use args to parse json path.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=61.0.0",
-  "json>=2.0.9",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/pytest_himark/plugin.py
+++ b/src/pytest_himark/plugin.py
@@ -7,7 +7,7 @@ def pytest_addoption(parser):
         action='store',
         dest='markers_from_json',
         default='',
-        help='Set the path where to look for config.json containing enabled markers declaration.'
+        help='--json=markers_from_json. Set the path where to look for config.json containing enabled markers declaration.'
     )
 
 

--- a/src/pytest_himark/plugin.py
+++ b/src/pytest_himark/plugin.py
@@ -17,9 +17,10 @@ def pytest_load_initial_conftests(args):
         if arg.startswith("--json="):
             json_path = arg.replace("--json=", "")
 
-    with open(json_path, "r") as file:
-        config = json.load(file)
-        markers = config.get("markers", list())
+    if json_path is not None:
+        with open(json_path, "r") as file:
+            config = json.load(file)
+            markers = config.get("markers", list())
 
     # lists the enabled markers
     markers_list = list()

--- a/src/pytest_himark/plugin.py
+++ b/src/pytest_himark/plugin.py
@@ -13,6 +13,8 @@ def pytest_addoption(parser):
 
 def pytest_load_initial_conftests(args):
     json_path = None
+    markers_list = list()
+
     for arg in args:
         if arg.startswith("--json="):
             json_path = arg.replace("--json=", "")
@@ -22,11 +24,10 @@ def pytest_load_initial_conftests(args):
             config = json.load(file)
             markers = config.get("markers", list())
 
-    # lists the enabled markers
-    markers_list = list()
-    for marker in markers:
-        if markers.get(marker) is True:
-            markers_list.append(marker)
+        # lists the enabled markers
+        for marker in markers:
+            if markers.get(marker) is True:
+                markers_list.append(marker)
 
     # make an OR of the previously listed enabled markers and pass it with the -m option to the command line
     if len(markers_list) > 0:

--- a/src/pytest_himark/plugin.py
+++ b/src/pytest_himark/plugin.py
@@ -2,7 +2,8 @@ import json
 
 
 def pytest_addoption(parser):
-    parser.addoption(
+    group = parser.getgroup("himark")
+    group.addoption(
         '--json',
         action='store',
         dest='markers_from_json',

--- a/src/pytest_himark/plugin.py
+++ b/src/pytest_himark/plugin.py
@@ -2,36 +2,31 @@ import json
 
 
 def pytest_addoption(parser):
-    group = parser.getgroup('himark')
-    group.addoption(
+    parser.addoption(
         '--json',
         action='store',
-        dest='JSON',
+        dest='markers_from_json',
         default='',
         help='Set the path where to look for config.json containing enabled markers declaration.'
     )
 
 
-def pytest_load_initial_conftests(early_config, parser, args):
-    group = parser.getgroup('himark')
-    json_path = group.options.json
+def pytest_load_initial_conftests(args):
+    json_path = None
+    for arg in args:
+        if arg.startswith("--json="):
+            json_path = arg.replace("--json=", "")
 
     with open(json_path, "r") as file:
         config = json.load(file)
-        hardware = config.get("markers", list())
-        metadata = config.get("metadata", list())
-
-    # add metadata from json
-    for data in metadata:
-        early_config._metadata[data] = metadata.get(data)
+        markers = config.get("markers", list())
 
     # lists the enabled markers
-    hwlist = list()
-    for hw in hardware:
-        if hardware.get(hw) is True:
-            hwlist.append(hw)
+    markers_list = list()
+    for marker in markers:
+        if markers.get(marker) is True:
+            markers_list.append(marker)
 
     # make an OR of the previously listed enabled markers and pass it with the -m option to the command line
-    if len(hwlist) > 0:
-        args[:] = ["-m", " or ".join(hwlist)] + args
-
+    if len(markers_list) > 0:
+        args[:] = ["-m", " or ".join(markers_list)] + args

--- a/tests/config.json
+++ b/tests/config.json
@@ -2,9 +2,5 @@
     "markers": {
         "marker1": false,
         "marker2": true
-    },
-
-    "metadata": {
-        "description": "this is an additional metadata for potential report."
     }
 }

--- a/tests/config_disabled.json
+++ b/tests/config_disabled.json
@@ -1,0 +1,6 @@
+{
+    "markers": {
+        "marker1": false,
+        "marker2": false
+    }
+}

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -1,4 +1,4 @@
-def test_bar_fixture(pytester):
+def test_json_filter(pytester):
     """Make sure that pytest accepts our fixture."""
 
     # create a temporary pytest test module
@@ -14,13 +14,12 @@ def test_bar_fixture(pytester):
 
     # run pytest with the following cmd args
     result = pytester.runpytest(
-        '--json=tests\config.json',
+        '--json=tests/config.json',
         '-v'
     )
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*::test_marker1 SKIPPED*',
         '*::test_marker2 PASSED*',
     ])
 

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -35,5 +35,5 @@ def test_help_message(pytester):
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
         'himark:',
-        '*--json=JSON*Set the path where to look for config.json containing enabled markers declaration.',
+        '*--json=markers_from_json*Set the path where to look for config.json containing enabled markers declaration.',
     ])

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -14,7 +14,7 @@ def test_bar_fixture(pytester):
 
     # run pytest with the following cmd args
     result = pytester.runpytest(
-        '--json=.\config.json',
+        '--json=tests\config.json',
         '-v'
     )
 

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -28,7 +28,7 @@ def test_json_filter(pytester):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*::test_marker2 PASSED*',
+        '::test_marker2 PASSED*',
     ])
 
     # make sure that we get a '0' exit code for the testsuite

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -4,7 +4,7 @@ current_directory = Path(__file__).parent
 config_json = current_directory.joinpath('config.json')
 
 
-def test_json_filter(pytester):
+def test_json_filter1(pytester):
     """Make sure that pytest accepts our fixture."""
 
     # create a temporary pytest test module
@@ -28,7 +28,38 @@ def test_json_filter(pytester):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '::test_marker2 PASSED*',
+        'test_json_filter.py::test_marker2 PASSED',
+    ])
+
+    # make sure that we get a '0' exit code for the testsuite
+    assert result.ret == 0
+
+
+def test_json_filter2(pytester):
+    """Make sure that pytest accepts our fixture."""
+
+    # create a temporary pytest test module
+    pytester.makepyfile("""
+        import pytest
+        
+        @pytest.mark.marker2
+        def test_marker1():
+            assert True
+            
+        @pytest.mark.marker1
+        def test_marker2():
+            assert True
+    """)
+
+    # run pytest with the following cmd args
+    result = pytester.runpytest(
+        f'--json={config_json}',
+        '-vvv'
+    )
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        'test_json_filter.py::test_marker1 PASSED',
     ])
 
     # make sure that we get a '0' exit code for the testsuite

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -23,7 +23,7 @@ def test_json_filter(pytester):
     # run pytest with the following cmd args
     result = pytester.runpytest(
         f'--json={config_json}',
-        '-v'
+        '-vvv'
     )
 
     # fnmatch_lines does an assertion internally

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -9,6 +9,8 @@ def test_json_filter(pytester):
 
     # create a temporary pytest test module
     pytester.makepyfile("""
+        import pytest
+        
         @pytest.mark.marker1
         def test_marker1():
             assert True

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -5,7 +5,7 @@ config_json = current_directory.joinpath('config.json')
 
 
 def test_json_filter1(pytester):
-    """Make sure that pytest accepts our fixture."""
+    """Check that only tests matching the marker from config.json is executed."""
 
     # create a temporary pytest test module
     pytester.makepyfile("""
@@ -18,6 +18,9 @@ def test_json_filter1(pytester):
         @pytest.mark.marker2
         def test_marker2():
             assert True
+        
+        def test_marker3():
+            assert True
     """)
 
     # run pytest with the following cmd args
@@ -28,7 +31,10 @@ def test_json_filter1(pytester):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        'test_json_filter.py::test_marker2 PASSED',
+        '*::test_marker2 PASSED*',
+    ])
+    result.stdout.no_fnmatch_line([
+        '*::test_marker1 PASSED*',
     ])
 
     # make sure that we get a '0' exit code for the testsuite
@@ -36,7 +42,7 @@ def test_json_filter1(pytester):
 
 
 def test_json_filter2(pytester):
-    """Make sure that pytest accepts our fixture."""
+    """Check that only tests matching the marker from config.json is executed."""
 
     # create a temporary pytest test module
     pytester.makepyfile("""
@@ -49,6 +55,9 @@ def test_json_filter2(pytester):
         @pytest.mark.marker1
         def test_marker2():
             assert True
+            
+        def test_marker3():
+            assert True
     """)
 
     # run pytest with the following cmd args
@@ -59,7 +68,45 @@ def test_json_filter2(pytester):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        'test_json_filter.py::test_marker1 PASSED',
+        '*::test_marker1 PASSED*',
+    ])
+    result.stdout.no_fnmatch_line([
+        '*::test_marker2 PASSED*',
+    ])
+
+    # make sure that we get a '0' exit code for the testsuite
+    assert result.ret == 0
+
+
+def test_json_filter_none(pytester):
+    """Check that all tests are executed when no json is used or if all markers are disabled."""
+
+    # create a temporary pytest test module
+    pytester.makepyfile("""
+        import pytest
+        
+        @pytest.mark.marker2
+        def test_marker1():
+            assert True
+            
+        @pytest.mark.marker1
+        def test_marker2():
+            assert True
+        
+        def test_marker3():
+            assert True
+    """)
+
+    # run pytest with the following cmd args
+    result = pytester.runpytest(
+        '-vvv'
+    )
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_marker1 PASSED*',
+        '*::test_marker2 PASSED*',
+        '*::test_marker3 PASSED*',
     ])
 
     # make sure that we get a '0' exit code for the testsuite

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -1,3 +1,9 @@
+from pathlib import Path
+
+current_directory = Path(__file__).parent
+config_json = current_directory.joinpath('config.json')
+
+
 def test_json_filter(pytester):
     """Make sure that pytest accepts our fixture."""
 
@@ -14,7 +20,7 @@ def test_json_filter(pytester):
 
     # run pytest with the following cmd args
     result = pytester.runpytest(
-        '--json=tests/config.json',
+        f'--json={config_json}',
         '-v'
     )
 

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 current_directory = Path(__file__).parent
 config_json = current_directory.joinpath('config.json')
+config_disabled_json = current_directory.joinpath('config_disabled.json')
 
 
 def test_json_filter1(pytester):
@@ -33,9 +34,9 @@ def test_json_filter1(pytester):
     result.stdout.fnmatch_lines([
         '*::test_marker2 PASSED*',
     ])
-    result.stdout.no_fnmatch_line([
+    result.stdout.no_fnmatch_line(
         '*::test_marker1 PASSED*',
-    ])
+    )
 
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
@@ -70,16 +71,16 @@ def test_json_filter2(pytester):
     result.stdout.fnmatch_lines([
         '*::test_marker1 PASSED*',
     ])
-    result.stdout.no_fnmatch_line([
-        '*::test_marker2 PASSED*',
-    ])
+    result.stdout.no_fnmatch_line(
+        '*::test_marker2 PASSED*'
+    )
 
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
 
 
 def test_json_filter_none(pytester):
-    """Check that all tests are executed when no json is used or if all markers are disabled."""
+    """Check that all tests are executed when no json is used."""
 
     # create a temporary pytest test module
     pytester.makepyfile("""
@@ -99,6 +100,42 @@ def test_json_filter_none(pytester):
 
     # run pytest with the following cmd args
     result = pytester.runpytest(
+        '-vvv'
+    )
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_marker1 PASSED*',
+        '*::test_marker2 PASSED*',
+        '*::test_marker3 PASSED*',
+    ])
+
+    # make sure that we get a '0' exit code for the testsuite
+    assert result.ret == 0
+
+
+def test_json_filter_disabled(pytester):
+    """Check that all tests are executed when all markers are disabled."""
+
+    # create a temporary pytest test module
+    pytester.makepyfile("""
+        import pytest
+        
+        @pytest.mark.marker2
+        def test_marker1():
+            assert True
+            
+        @pytest.mark.marker1
+        def test_marker2():
+            assert True
+        
+        def test_marker3():
+            assert True
+    """)
+
+    # run pytest with the following cmd args
+    result = pytester.runpytest(
+        f'--json={config_disabled_json}',
         '-vvv'
     )
 

--- a/tests/test_himark.py
+++ b/tests/test_himark.py
@@ -33,14 +33,3 @@ def test_json_filter(pytester):
 
     # make sure that we get a '0' exit code for the testsuite
     assert result.ret == 0
-
-
-def test_help_message(pytester):
-    result = pytester.runpytest(
-        '--help',
-    )
-    # fnmatch_lines does an assertion internally
-    result.stdout.fnmatch_lines([
-        'himark:',
-        '*--json=markers_from_json*Set the path where to look for config.json containing enabled markers declaration.',
-    ])

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py38,py39,py310,py311,py312,pypy3,flake8
 
 [testenv]
 deps = pytest>=6.2.0
-commands = pytest {posargs:tests}
+commands = pytest --json=tests/config.json {posargs:tests}
 
 [testenv:flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py38,py39,py310,py311,py312,pypy3,flake8
 
 [testenv]
 deps = pytest>=6.2.0
-commands = pytest --json=tests/config.json {posargs:tests}
+commands = pytest {posargs:tests}
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
- Drops usage of early_config for getting json path as this cannot work
- Get json path from parsing the args
- Change the destination of the json argument to prevent mixing with other potential options
- Remove the possibility to add metadata from the user's config.json since early_config does not contain metadata, also this feature was not originally intended